### PR TITLE
[Feature] Ini class

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -46,4 +46,20 @@ class Assert extends \Webmozart\Assert\Assert
             ));
         }
     }
+
+    /**
+     * Convert the given value to a string representation.
+     *
+     * This returns the class name of objects instead of `object`.
+     * This returns quoted string values instead of `string`.
+     * This returns `false` or `true` instead of `boolean`.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    public static function valueToString($value)
+    {
+        return parent::valueToString($value);
+    }
 }

--- a/src/Ini.php
+++ b/src/Ini.php
@@ -75,6 +75,34 @@ class Ini
     }
 
     /**
+     * Parses a bytes string representation value of the given key and returns it as an int.
+     *
+     * Note that floats are converted to ints before being multiplied by their unit. Thus 5.5M == 5M and 0.5M == 0.
+     *
+     * @param string   $key
+     * @param int|null $default
+     *
+     * @return int|null
+     */
+    public static function getBytes($key, $default = null)
+    {
+        $value = ini_get($key);
+
+        if ($value === false || $value === '') {
+            return $default;
+        }
+
+        if ($value === '-1') {
+            return -1;
+        }
+
+        $unit = preg_replace('/[^bkmgtpezy]/i', '', $value);
+        $size = preg_replace('/[^0-9\.]/', '', $value);
+
+        return ((int) $size) * ($unit ? pow(1024, stripos('bkmgtpezy', $unit[0])) : 1);
+    }
+
+    /**
      * Set a new value for the given key.
      *
      * @param string $key

--- a/src/Ini.php
+++ b/src/Ini.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Bolt\Common;
+
+/**
+ * Wrapper around ini_get()/ini_set().
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class Ini
+{
+    /** @var array [string key => bool editable] */
+    private static $keys;
+
+    /**
+     * Checks whether the given key exists.
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    public static function has($key)
+    {
+        if (static::$keys === null) {
+            static::readKeys();
+        }
+
+        return array_key_exists($key, static::$keys);
+    }
+
+    /**
+     * Returns the value of the given key or the given default if it does not exist.
+     *
+     * @param string     $key
+     * @param mixed|null $default
+     *
+     * @return mixed
+     */
+    public static function get($key, $default = null)
+    {
+        $value = ini_get($key);
+
+        return $value === false ? $default : $value;
+    }
+
+    /**
+     * Returns the value of the given key filtered to a boolean or the given default if it does not exist.
+     *
+     * @param string    $key
+     * @param bool|null $default
+     *
+     * @return bool|null
+     */
+    public static function getBool($key, $default = null)
+    {
+        $value = static::get($key, $default);
+
+        return $value !== null ? filter_var($value, FILTER_VALIDATE_BOOLEAN) : null;
+    }
+
+    /**
+     * Returns the value of the given key filtered to an int or float or the given default if it does not exist.
+     *
+     * @param string         $key
+     * @param int|float|null $default
+     *
+     * @return int|float|null
+     */
+    public static function getNumeric($key, $default = null)
+    {
+        $value = static::get($key, $default);
+
+        return $value !== null ? $value + 0 : null;
+    }
+
+    /**
+     * Set a new value for the given key.
+     *
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @throws \InvalidArgumentException when the value is not scalar or null.
+     * @throws \RuntimeException when the key does not exist, it is not editable, or some unknown reason.
+     */
+    public static function set($key, $value)
+    {
+        Assert::nullOrScalar($value, 'ini values must be scalar or null. Got: %s');
+
+        $ex = null;
+        set_error_handler(function ($severity, $message, $file, $line) use (&$ex) {
+            $ex = new \ErrorException($message, 0, $severity, $file, $line);
+        });
+
+        try {
+            $result = ini_set($key, $value === false ? '0' : $value);
+        } finally {
+            restore_error_handler();
+        }
+
+        if ($result === false || $ex !== null) {
+            if (!static::has($key)) {
+                throw new \RuntimeException(sprintf('The ini option "%s" does not exist. New ini options cannot be added.', $key), 0, $ex);
+            }
+            if (!static::$keys[$key]) {
+                throw new \RuntimeException(sprintf('Unable to change ini option "%s", because it is not editable at runtime.', $key, $value), 0, $ex);
+            }
+
+            $value = Assert::valueToString($value);
+            throw new \RuntimeException(sprintf('Unable to change ini option "%s" to %s.', $key, $value), 0, $ex);
+        }
+    }
+
+    /**
+     * Process all ini options to get list of keys and determine which ones are editable.
+     */
+    private static function readKeys()
+    {
+        static::$keys = [];
+
+        foreach (ini_get_all() as $key => $value) {
+            static::$keys[$key] = $value['access'] === 1 /* user */ || $value['access'] === 7 /* all */;
+        }
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/Ini.php
+++ b/src/Ini.php
@@ -29,37 +29,38 @@ class Ini
     }
 
     /**
-     * Returns the value of the given key or the given default if it does not exist.
+     * Returns the string value of the given key or the given default if it is empty or does not exist.
      *
-     * @param string     $key
-     * @param mixed|null $default
+     * @param string      $key
+     * @param string|null $default
      *
-     * @return mixed
+     * @return string|null
      */
-    public static function get($key, $default = null)
+    public static function getStr($key, $default = null)
     {
         $value = ini_get($key);
 
-        return $value === false ? $default : $value;
+        return $value === false || $value === '' ? $default : $value;
     }
 
     /**
-     * Returns the value of the given key filtered to a boolean or the given default if it does not exist.
+     * Returns the value of the given key filtered to a boolean.
      *
-     * @param string    $key
-     * @param bool|null $default
+     * If the key does not exist false is returned.
      *
-     * @return bool|null
+     * @param string $key
+     *
+     * @return bool
      */
-    public static function getBool($key, $default = null)
+    public static function getBool($key)
     {
-        $value = static::get($key, $default);
-
-        return $value !== null ? filter_var($value, FILTER_VALIDATE_BOOLEAN) : null;
+        return filter_var(ini_get($key), FILTER_VALIDATE_BOOLEAN);
     }
 
     /**
-     * Returns the value of the given key filtered to an int or float or the given default if it does not exist.
+     * Returns the value of the given key filtered to an int or float.
+     *
+     * If the key does not exist or the value is empty the given default is returned.
      *
      * @param string         $key
      * @param int|float|null $default
@@ -68,9 +69,9 @@ class Ini
      */
     public static function getNumeric($key, $default = null)
     {
-        $value = static::get($key, $default);
+        $value = ini_get($key);
 
-        return $value !== null ? $value + 0 : null;
+        return $value === false || $value === '' ? $default : $value + 0;
     }
 
     /**

--- a/src/Ini.php
+++ b/src/Ini.php
@@ -120,8 +120,9 @@ class Ini
             $ex = new \ErrorException($message, 0, $severity, $file, $line);
         });
 
+        $iniValue = $value === false ? '0' : (string) $value;
         try {
-            $result = ini_set($key, $value === false ? '0' : $value);
+            $result = ini_set($key, $iniValue);
         } finally {
             restore_error_handler();
         }
@@ -134,6 +135,12 @@ class Ini
                 throw new \RuntimeException(sprintf('Unable to change ini option "%s", because it is not editable at runtime.', $key, $value), 0, $ex);
             }
 
+            $value = Assert::valueToString($value);
+            throw new \RuntimeException(sprintf('Unable to change ini option "%s" to %s.', $key, $value), 0, $ex);
+        }
+
+        // HHVM sets values w/o error, but the change is not actually applied.
+        if (ini_get($key) !== $iniValue) {
             $value = Assert::valueToString($value);
             throw new \RuntimeException(sprintf('Unable to change ini option "%s" to %s.', $key, $value), 0, $ex);
         }

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -72,4 +72,9 @@ class AssertTest extends TestCase
     {
         Assert::isIterable(new \stdClass());
     }
+
+    public function testValueToString()
+    {
+        $this->assertSame('"foo"', Assert::valueToString('foo'));
+    }
 }

--- a/tests/IniTest.php
+++ b/tests/IniTest.php
@@ -38,10 +38,15 @@ class IniTest extends TestCase
         $this->assertFalse(Ini::has(static::NONEXISTENT_KEY));
     }
 
-    public function testGet()
+    public function testGetStr()
     {
-        $this->assertSame(ini_get(static::STR_KEY), Ini::get(static::STR_KEY));
-        $this->assertNull(Ini::get(static::NONEXISTENT_KEY));
+        ini_set(static::STR_KEY, 'foo');
+        $this->assertSame('foo', Ini::getStr(static::STR_KEY));
+
+        ini_set(static::STR_KEY, '');
+        $this->assertSame('default', Ini::getStr(static::STR_KEY, 'default'));
+
+        $this->assertNull(Ini::getStr(static::NONEXISTENT_KEY));
     }
 
     public function testGetBool()
@@ -49,11 +54,13 @@ class IniTest extends TestCase
         ini_set(static::BOOL_KEY, '0');
         $this->assertFalse(Ini::getBool(static::BOOL_KEY));
 
+        ini_set(static::BOOL_KEY, '');
+        $this->assertFalse(Ini::getBool(static::BOOL_KEY));
+
         ini_set(static::BOOL_KEY, '1');
         $this->assertTrue(Ini::getBool(static::BOOL_KEY));
 
-
-        $this->assertNull(Ini::getBool(static::NONEXISTENT_KEY));
+        $this->assertFalse(Ini::getBool(static::NONEXISTENT_KEY));
     }
 
     public function testGetNumeric()
@@ -63,6 +70,9 @@ class IniTest extends TestCase
 
         ini_set(static::INT_KEY, '3.2');
         $this->assertSame(3.2, Ini::getNumeric(static::INT_KEY));
+
+        ini_set(static::INT_KEY, '');
+        $this->assertSame(4.0, Ini::getNumeric(static::INT_KEY, 4.0));
 
         $this->assertNull(Ini::getNumeric(static::NONEXISTENT_KEY));
     }

--- a/tests/IniTest.php
+++ b/tests/IniTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Bolt\Common\Tests;
+
+use Bolt\Common\Ini;
+use PHPUnit\Framework\TestCase;
+
+class IniTest extends TestCase
+{
+    const STR_KEY = 'session.save_path';
+    const BOOL_KEY = 'assert.bail';
+    const INT_KEY = 'precision';
+    const READ_ONLY_KEY = 'allow_url_fopen';
+    const TRIGGERS_ERROR_KEY = 'session.name';
+    const NONEXISTENT_KEY = 'herp.derp';
+
+    private $backup;
+
+    protected function setUp()
+    {
+        $this->backup = [
+            static::STR_KEY  => ini_get(static::STR_KEY),
+            static::BOOL_KEY => ini_get(static::BOOL_KEY),
+            static::INT_KEY  => ini_get(static::INT_KEY),
+        ];
+    }
+
+    protected function tearDown()
+    {
+        foreach ($this->backup as $key => $value) {
+            ini_set($key, $value);
+        }
+    }
+
+    public function testHas()
+    {
+        $this->assertTrue(Ini::has(static::STR_KEY));
+        $this->assertFalse(Ini::has(static::NONEXISTENT_KEY));
+    }
+
+    public function testGet()
+    {
+        $this->assertSame(ini_get(static::STR_KEY), Ini::get(static::STR_KEY));
+        $this->assertNull(Ini::get(static::NONEXISTENT_KEY));
+    }
+
+    public function testGetBool()
+    {
+        ini_set(static::BOOL_KEY, '0');
+        $this->assertFalse(Ini::getBool(static::BOOL_KEY));
+
+        ini_set(static::BOOL_KEY, '1');
+        $this->assertTrue(Ini::getBool(static::BOOL_KEY));
+
+
+        $this->assertNull(Ini::getBool(static::NONEXISTENT_KEY));
+    }
+
+    public function testGetNumeric()
+    {
+        ini_set(static::INT_KEY, '2');
+        $this->assertSame(2, Ini::getNumeric(static::INT_KEY));
+
+        ini_set(static::INT_KEY, '3.2');
+        $this->assertSame(3.2, Ini::getNumeric(static::INT_KEY));
+
+        $this->assertNull(Ini::getNumeric(static::NONEXISTENT_KEY));
+    }
+
+    public function testSet()
+    {
+        Ini::set(static::STR_KEY, 'foo');
+        $this->assertSame('foo', ini_get(static::STR_KEY));
+    }
+
+    public function testSetBoolean()
+    {
+        Ini::set(static::BOOL_KEY, false);
+        $this->assertSame('0', ini_get(static::BOOL_KEY));
+
+        Ini::set(static::BOOL_KEY, true);
+        $this->assertSame('1', ini_get(static::BOOL_KEY));
+    }
+
+    public function testSetInvalidType()
+    {
+        $this->setExpectedException(
+            \InvalidArgumentException::class,
+            'ini values must be scalar or null. Got: array'
+        );
+
+        Ini::set(static::INT_KEY, []);
+    }
+
+    public function testSetInvalidValue()
+    {
+        $this->setExpectedException(
+            \RuntimeException::class,
+            sprintf('Unable to change ini option "%s" to -2.', static::INT_KEY)
+        );
+
+        Ini::set(static::INT_KEY, -2);
+    }
+
+    public function testSetInvalidValueErrorTriggered()
+    {
+        try {
+            Ini::set(static::TRIGGERS_ERROR_KEY, '');
+            $this->fail('Exception should be thrown');
+        } catch (\Exception $e) {
+        }
+
+        $this->assertInstanceOf(
+            \ErrorException::class,
+            $e->getPrevious(),
+            'set() should have caught a triggered error and thrown it as an ErrorException.'
+        );
+    }
+
+    public function testSetNewKey()
+    {
+        $this->setExpectedException(
+            \RuntimeException::class,
+            sprintf('The ini option "%s" does not exist. New ini options cannot be added.', static::NONEXISTENT_KEY)
+        );
+
+        Ini::set(static::NONEXISTENT_KEY, 'foo');
+    }
+
+    public function testSetUnauthorized()
+    {
+        $this->setExpectedException(
+            \RuntimeException::class,
+            sprintf('Unable to change ini option "%s", because it is not editable at runtime.', static::READ_ONLY_KEY)
+        );
+
+        Ini::set(static::READ_ONLY_KEY, true);
+    }
+}


### PR DESCRIPTION
This adds a wrapper around `ini_get()`/`ini_set()`.

Most of this functionality was in `Bolt\Session\IniBag`. This abstracts it a bit more and only provides functionality for dealing with a single key/value a time.

## Usage
```php
Ini::get('session.name'); // returns string
Ini::get('extension_key?', 'bolt'); // returns 'bolt' if key does not exist.
Ini::getBool('allow_url_fopen'); // returns true or false (not "1"/"0")
Ini::getNumeric('precision'); // returns 14 (not "14")

Ini::set('allow_url_fopen', true); // throws exception since it is not editable
Ini::set('precision', -2); // throws exception since it is not a valid value
Ini::set('wut', 'derp'); // throws exception since the option does not exist
Ini::set('session.name', new \stdClass); // throws exception since the value is not scalar or null
```

## [RFC] Default values
Maybe there's a better way to handle default values. Currently the default is only used if the key does not exist. Unfortunately `ini_get` returns an empty string for _null_ values as well as _false_ values. In turn, `get()` doesn't know if you want a string or a boolean and thus how to handle `""`.

One solution may be to remove `get()`, or rename it to something else like `getRaw()`, and add a `getStr()`. So `getStr()` handles `""` as null and uses default value, and `getBool()` handles `""` as _false_ (this probably means the default value of the default parameter should be _false_ instead of _null_.

EDIT: I went ahead and implement a version of these ^ changes.