### PR TITLE
[Feature] Serializer class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "seld/jsonlint": "^1.4",
+        "symfony/polyfill-php70": "^1.4",
         "symfony/polyfill-php71": "^1.0",
         "webmozart/assert": "^1.2"
     },

--- a/src/Serialization.php
+++ b/src/Serialization.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Bolt\Common;
+
+use Bolt\Common\Exception\DumpException;
+use Bolt\Common\Exception\ParseException;
+
+/**
+ * Wrapper around serialize()/unserialize().
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class Serialization
+{
+    /**
+     * Dump (Serialize) value.
+     *
+     * @param mixed $value
+     *
+     * @throws DumpException when serializing fails.
+     *
+     * @return string
+     */
+    public static function dump($value)
+    {
+        try {
+            return serialize($value);
+        } catch (\Error $e) {
+        } catch (\Exception $e) {
+        }
+
+        throw new DumpException('Error serializing value. ' . $e->getMessage(), 0, $e);
+    }
+
+    /**
+     * Parse (Unserialize) value.
+     *
+     * @param string $value
+     * @param array  $options
+     *
+     * @throws ParseException when unserializing fails.
+     *
+     * @return mixed
+     */
+    public static function parse($value, $options = [])
+    {
+        static $handler;
+        if (!$handler) {
+            $handler = function ($severity, $message, $file, $line) {
+                throw new \ErrorException($message, 0, $severity, $file, $line);
+            };
+        }
+
+        set_error_handler($handler);
+        $unserializeHandler = ini_set('unserialize_callback_func', __CLASS__ . '::handleUnserializeCallback');
+        try {
+            if (PHP_VERSION_ID < 70000) {
+                return unserialize($value);
+            }
+
+            return unserialize($value, $options);
+        } catch (ParseException $e) {
+            throw $e;
+        } catch (\Error $e) {
+        } catch (\Exception $e) {
+        } finally {
+            restore_error_handler();
+            ini_set('unserialize_callback_func', $unserializeHandler);
+        }
+
+        throw new ParseException('Error parsing serialized value.', -1, null, $e);
+    }
+
+    /**
+     * @internal
+     *
+     * @param string $class
+     */
+    public static function handleUnserializeCallback($class)
+    {
+        throw new ParseException('Error parsing serialized value. Could not find class: ' . $class);
+    }
+}

--- a/tests/SerializationTest.php
+++ b/tests/SerializationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bolt\Common\Tests;
+
+use Bolt\Common\Serialization;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Bolt\Common\Serialization
+ *
+ * @author Gawain Lynch <gawain.lynch@gmail.com>
+ */
+class SerializationTest extends TestCase
+{
+    public function testDump()
+    {
+        $result = Serialization::dump(new \stdClass());
+        $this->assertSame(serialize(new \stdClass()), $result);
+    }
+
+    /**
+     * @expectedException \Bolt\Common\Exception\DumpException
+     * @expectedExceptionMessage Error serializing value. Serialization of 'Closure' is not allowed
+     */
+    public function testDumpInvalid()
+    {
+        Serialization::dump(function () {});
+    }
+
+    public function testParseSimple()
+    {
+        $result = Serialization::parse(serialize(new \stdClass()));
+        $this->assertInstanceOf(\stdClass::class, $result);
+    }
+
+    /**
+     * @expectedException \Bolt\Common\Exception\ParseException
+     * @expectedExceptionMessage Error parsing serialized value.
+     */
+    public function testParseInvalidData()
+    {
+        Serialization::parse('O:9:"stdClass":0:{}');
+    }
+
+    /**
+     * @expectedException \Bolt\Common\Exception\ParseException
+     * @expectedExceptionMessage Error parsing serialized value. Could not find class: ThisClassShouldNotExistsDueToDropBears
+     */
+    public function testParseClassNotFound()
+    {
+        Serialization::parse('O:38:"ThisClassShouldNotExistsDueToDropBears":0:{}');
+    }
+}


### PR DESCRIPTION
This is a wrapper for `serialize()` and `unserialize()` that throws exceptions when things go wrong.

## Usage
```php
$serialized = Serializer::dump(new \stdClass());

$object = Serializer::parse($serialized);
```

Method names, _dump_ and _parse_, are consistent with our `Json` class and with Symfony's Yaml parser.
I'm open to suggestions for the class name as I'm not thrilled with it.