### PR TITLE
Added CS Tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /vendor
 composer.lock
+
+/.php_cs
+/.php_cs.cache
+/phpcs.xml
+/phpunit.xml

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,6 @@
+<?php
+
+return Bolt\CsFixer\Config::create()
+    ->addRules(Bolt\CsFixer\Rules::create()->risky())
+    ->in('.')
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,21 @@ matrix:
     - php: hhvm
 
 before_install:
+  # Remove PHP CS Fixer for PHP 5.5 since it requires PHP 5.6
+  - if [[ $TRAVIS_PHP_VERSION == "5.5" || $TRAVIS_PHP_VERSION == "hhvm" ]]; then composer remove friendsofphp/php-cs-fixer --dev --no-update; fi
 
 before_script:
   # Set up Composer
   - composer self-update || true
-  - composer install --prefer-dist
+  - composer install
 
 script:
   # PHPUnit
   - vendor/bin/phpunit
+  # PHP CodeSniffer
+  - vendor/bin/phpcs -p --report=summary
+  # PHP CS Fixer (if >=5.6)
+  - if [[ $TRAVIS_PHP_VERSION != "5.5" && $TRAVIS_PHP_VERSION != "hhvm" ]]; then vendor/bin/php-cs-fixer fix --dry-run; fi
 
 after_script:
 

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,19 @@
         "webmozart/assert": "^1.2"
     },
     "require-dev": {
+        "bolt/codingstyle": "^2.0@dev",
+        "escapestudios/symfony2-coding-standard": "^3.0@dev",
+        "friendsofphp/php-cs-fixer": "^2.4",
         "lstrojny/phpunit-function-mocker": "0.3.0",
         "phpunit/phpunit": "^4.8",
         "symfony/phpunit-bridge": "^3.3"
+    },
+    "scripts": {
+        "test": "phpunit",
+        "lint": [
+            "phpcbf",
+            "php-cs-fixer fix"
+        ]
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ruleset name="Project">
+    <arg name="colors"/>
+
+    <file>src</file>
+    <file>tests</file>
+
+    <rule ref="vendor/bolt/codingstyle/Bolt">
+        <!-- Ignore silencing here, since we are wrapping built in methods that do stupid things -->
+        <exclude name="Generic.PHP.NoSilencedErrors"/>
+    </rule>
+</ruleset>


### PR DESCRIPTION
Required and configured PHP CS Fixer and PHP_CodeSniffer.
Both can be ran and automatically apply fixes by running `composer lint`.
They are also hooked into Travis which will fail builds if there are errors.