### PR TITLE
Moar JSON

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "bolt/codingstyle": "^2.0@dev",
         "escapestudios/symfony2-coding-standard": "^3.0@dev",
         "friendsofphp/php-cs-fixer": "^2.4",
-        "lstrojny/phpunit-function-mocker": "0.3.0",
         "phpunit/phpunit": "^4.8",
         "symfony/phpunit-bridge": "^3.3"
     },
@@ -38,7 +37,10 @@
     "autoload-dev": {
         "psr-4": {
             "Bolt\\Common\\Tests\\": "tests"
-        }
+        },
+        "files": [
+            "tests/Fixtures/JsonMocker.php"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -69,6 +69,30 @@ class ParseException extends \RuntimeException
     }
 
     /**
+     * Gets the message without line number and snippet.
+     *
+     * @return string
+     */
+    public function getRawMessage()
+    {
+        return $this->rawMessage;
+    }
+
+    /**
+     * Sets the message.
+     *
+     * Don't include line number and snippet in this as they will be merged separately.
+     *
+     * @param string $rawMessage
+     */
+    public function setRawMessage($rawMessage)
+    {
+        $this->rawMessage = $rawMessage;
+
+        $this->updateRepr();
+    }
+
+    /**
      * Gets the line where the error occurred.
      *
      * @return int The file line
@@ -112,6 +136,9 @@ class ParseException extends \RuntimeException
         $this->updateRepr();
     }
 
+    /**
+     * Sets the exception message by joining the raw message, parsed line, and snippet.
+     */
     private function updateRepr()
     {
         $this->message = $this->rawMessage;

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -19,9 +19,10 @@ class ParseException extends \RuntimeException
      * @param string      $message    The error message
      * @param int         $parsedLine The line where the error occurred
      * @param string|null $snippet    The snippet of code near the problem
+     * @param int         $code       The code
      * @param \Throwable  $previous   The previous exception
      */
-    public function __construct($message, $parsedLine = -1, $snippet = null, $previous = null)
+    public function __construct($message, $parsedLine = -1, $snippet = null, $code = 0, $previous = null)
     {
         $this->parsedLine = $parsedLine;
         $this->snippet = $snippet;
@@ -29,7 +30,7 @@ class ParseException extends \RuntimeException
 
         $this->updateRepr();
 
-        parent::__construct($this->message, 0, $previous);
+        parent::__construct($this->message, $code, $previous);
     }
 
     /**
@@ -65,7 +66,7 @@ class ParseException extends \RuntimeException
 
         $message = 'JSON parsing failed: ' . $message;
 
-        return new static($message, $line, $snippet, $exception);
+        return new static($message, $line, $snippet, JSON_ERROR_SYNTAX, $exception);
     }
 
     /**

--- a/src/Json.php
+++ b/src/Json.php
@@ -29,7 +29,7 @@ final class Json
         $json = @json_encode($data, $options, $depth);
 
         if ($json === false) {
-            throw new DumpException(sprintf('JSON dumping failed: %s', json_last_error_msg()));
+            throw new DumpException(sprintf('JSON dumping failed: %s', json_last_error_msg()), json_last_error());
         }
 
         return $json;
@@ -54,9 +54,9 @@ final class Json
 
         $data = @json_decode($json, true, $depth, $options);
 
-        if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
-            if (json_last_error() === JSON_ERROR_UTF8) {
-                throw new ParseException(sprintf('JSON parsing failed: %s', json_last_error_msg()));
+        if ($data === null && ($code = json_last_error()) !== JSON_ERROR_NONE) {
+            if ($code === JSON_ERROR_UTF8) {
+                throw new ParseException(sprintf('JSON parsing failed: %s', json_last_error_msg()), -1, null, $code);
             }
 
             try {

--- a/src/Json.php
+++ b/src/Json.php
@@ -55,7 +55,7 @@ final class Json
         $data = @json_decode($json, true, $depth, $options);
 
         if ($data === null && ($code = json_last_error()) !== JSON_ERROR_NONE) {
-            if ($code === JSON_ERROR_UTF8) {
+            if ($code === JSON_ERROR_UTF8 || $code === JSON_ERROR_DEPTH) {
                 throw new ParseException(sprintf('JSON parsing failed: %s', json_last_error_msg()), -1, null, $code);
             }
 

--- a/src/Serialization.php
+++ b/src/Serialization.php
@@ -68,7 +68,7 @@ class Serialization
             ini_set('unserialize_callback_func', $unserializeHandler);
         }
 
-        throw new ParseException('Error parsing serialized value.', -1, null, $e);
+        throw new ParseException('Error parsing serialized value.', -1, null, 0, $e);
     }
 
     /**

--- a/tests/Fixtures/JsonMocker.php
+++ b/tests/Fixtures/JsonMocker.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Bolt\Common\Tests\Fixtures;
+
+// @codingStandardsIgnoreFile
+
+/**
+ * Proxies native JSON methods through this singleton so they can be easily modified.
+ *
+ * This only works for our Json class.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class JsonMocker
+{
+    /** @var callable */
+    private $encoder;
+    /** @var callable */
+    private $decoder;
+    /** @var callable */
+    private $lastCodeGetter;
+    /** @var callable */
+    private $lastMsgGetter;
+
+    /**
+     * Return the singleton instance.
+     *
+     * @return JsonMocker
+     */
+    public static function instance()
+    {
+        static $instance;
+        if (!$instance) {
+            static::register();
+            $instance = new static();
+        }
+
+        return $instance;
+    }
+
+    /**
+     * Register override functions for Bolt\Common namespace.
+     *
+     * We use eval() here so we can loop over methods to reduce boilerplate and so that our IDEs
+     * don't pick up these methods and try to auto complete to them instead of the native methods.
+     */
+    private static function register()
+    {
+        $code = <<<'PHP'
+namespace Bolt\Common;
+
+function %s() { return call_user_func_array([\%s::instance(), '%1$s'], func_get_args()); }
+PHP;
+        $methods = [
+            'json_decode',
+            'json_encode',
+            'json_last_error',
+            'json_last_error_msg',
+        ];
+        foreach ($methods as $name) {
+            eval(sprintf($code, $name, static::class));
+        }
+    }
+
+    private function __construct()
+    {
+        $this->reset();
+    }
+
+    public function reset()
+    {
+        $this->setEncoder();
+        $this->setDecoder();
+        $this->setLastCodeGetter();
+        $this->setLastMessageGetter();
+    }
+
+    public function setEncoder(callable $encoder = null)
+    {
+        $this->encoder = $encoder ?: 'json_encode';
+    }
+
+    public function setDecoder(callable $decoder = null)
+    {
+        $this->decoder = $decoder ?: 'json_decode';
+    }
+
+    public function setLastCodeGetter(callable $callable = null)
+    {
+        $this->lastCodeGetter = $callable ?: 'json_last_error';
+    }
+
+    public function setLastMessageGetter(callable $callable = null)
+    {
+        $this->lastMsgGetter = $callable ?: 'json_last_error_msg';
+    }
+
+    // @codingStandardsIgnoreStart
+
+    public function json_decode($value, $options = 0, $depth = 512)
+    {
+        return call_user_func_array($this->decoder, func_get_args());
+    }
+
+    public function json_encode($json, $assoc = false, $depth = 512, $options = 0)
+    {
+        return call_user_func_array($this->encoder, func_get_args());
+    }
+
+    public function json_last_error()
+    {
+        return call_user_func($this->lastCodeGetter);
+    }
+
+    public function json_last_error_msg()
+    {
+        return call_user_func($this->lastMsgGetter);
+    }
+}
+
+JsonMocker::instance();

--- a/tests/Fixtures/TestJsonable.php
+++ b/tests/Fixtures/TestJsonable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Bolt\Common\Tests\Fixtures;
+
+class TestJsonable implements \JsonSerializable
+{
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->data;
+    }
+}

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -102,10 +102,10 @@ class JsonTest extends TestCase
     public function testParseErrorUtf8()
     {
         $json = "{\"message\": \"\xA4\xA6\xA8\xB4\xB8\xBC\xBD\xBE\"}";
-        $this->expectParseException($json, -1, 'Malformed UTF-8 characters, possibly incorrectly encoded');
+        $this->expectParseException($json, -1, 'Malformed UTF-8 characters, possibly incorrectly encoded', JSON_ERROR_UTF8);
     }
 
-    private function expectParseException($json, $line, $text = null)
+    private function expectParseException($json, $line, $text = null, $code = JSON_ERROR_SYNTAX)
     {
         try {
             $result = Json::parse($json);
@@ -117,6 +117,7 @@ class JsonTest extends TestCase
             ));
         } catch (ParseException $e) {
             $this->assertSame($line, $e->getParsedLine());
+            $this->assertSame($code, $e->getCode());
             $actualMsg = $e->getMessage();
             $this->assertStringStartsWith('JSON parsing failed: ', $actualMsg);
             $actualMsg = substr($actualMsg, 21);

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -5,9 +5,9 @@ namespace Bolt\Common\Tests;
 use Bolt\Common\Exception\DumpException;
 use Bolt\Common\Exception\ParseException;
 use Bolt\Common\Json;
+use Bolt\Common\Tests\Fixtures\JsonMocker;
 use Bolt\Common\Tests\Fixtures\TestStringable;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Extension_FunctionMocker as FunctionMocker;
 
 class JsonTest extends TestCase
 {
@@ -226,33 +226,22 @@ class JsonTest extends TestCase
         }
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testDumpFail()
     {
-        $mock = FunctionMocker::start($this, 'Bolt\Common')
-            ->mockFunction('json_encode')
-            ->mockFunction('json_last_error_msg')
-            ->getMock()
-        ;
-        $mock
-            ->expects($this->once())
-            ->method('json_encode')
-            ->willReturn(false)
-        ;
-        $mock
-            ->expects($this->once())
-            ->method('json_last_error_msg')
-            ->willReturn('Unknown error')
-        ;
+        $mocker = JsonMocker::instance();
+        $mocker->setEncoder(function () {
+            return false;
+        });
+        $mocker->setLastMessageGetter(function () {
+            return 'Unknown error';
+        });
 
         $this->setExpectedException(DumpException::class, 'JSON dumping failed: Unknown error');
 
         try {
             Json::dump('');
         } finally {
-            FunctionMocker::tearDown();
+            $mocker->reset();
         }
     }
 

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -127,6 +127,15 @@ class JsonTest extends TestCase
         }
     }
 
+    /**
+     * @expectedException \Bolt\Common\Exception\ParseException
+     * @expectedExceptionMessage JSON parsing failed: Maximum stack depth exceeded
+     */
+    public function testParseErrorDepth()
+    {
+        Json::parse('[[["hi"]]]', 0, 1);
+    }
+
     public function testParseExceptionGettersSetters()
     {
         $ex = new ParseException('Uh oh.');

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -129,12 +129,14 @@ class JsonTest extends TestCase
     public function testParseExceptionGettersSetters()
     {
         $ex = new ParseException('Uh oh.');
+        $ex->setRawMessage('Whoops.');
         $ex->setParsedLine(5);
         $ex->setSnippet('foo bar');
 
+        $this->assertEquals('Whoops.', $ex->getRawMessage());
         $this->assertEquals(5, $ex->getParsedLine());
         $this->assertEquals('foo bar', $ex->getSnippet());
-        $this->assertEquals('Uh oh at line 5 (near "foo bar").', $ex->getMessage());
+        $this->assertEquals('Whoops at line 5 (near "foo bar").', $ex->getMessage());
     }
 
     public function testDumpSimpleJsonString()


### PR DESCRIPTION
- When dumping invalid UTF-8, attempt to fix it. This is something GMO needed a while ago, and we haven't had any issues since. Details and links to smarter people in code.
- Setting `JSON_ERROR_*` code as the `Parse/DumpException` code
- Added `ParseException::get/setRawMessage` - this makes extending easier.
- Fixed `ParseException` not being thrown when maximum stack depth is exceeded
- Updated `JsonTest` to not need to run some tests in a separate process with the _phpunit-function-mocker_ library.

I did struggle with the order of the `ParseException` parameters. I'm not sure if _code_ and _previous_ should come before _lineNumber_ and _snippet_ or before.
Any ideas or thoughts are welcome.