### PR TITLE
Thrower

### DIFF
--- a/src/Ini.php
+++ b/src/Ini.php
@@ -115,23 +115,13 @@ class Ini
     {
         Assert::nullOrScalar($value, 'ini values must be scalar or null. Got: %s');
 
-        static $handler;
-        if (!$handler) {
-            $handler = function ($severity, $message, $file, $line) {
-                throw new \ErrorException($message, 0, $severity, $file, $line);
-            };
-        }
-
         $iniValue = $value === false ? '0' : (string) $value;
 
         $result = false;
         $ex = null;
-        set_error_handler($handler);
         try {
-            $result = ini_set($key, $iniValue);
+            $result = Thrower::call('ini_set', $key, $iniValue);
         } catch (\Exception $ex) {
-        } finally {
-            restore_error_handler();
         }
 
         if ($result === false || $ex !== null) {

--- a/src/Serialization.php
+++ b/src/Serialization.php
@@ -44,27 +44,18 @@ class Serialization
      */
     public static function parse($value, $options = [])
     {
-        static $handler;
-        if (!$handler) {
-            $handler = function ($severity, $message, $file, $line) {
-                throw new \ErrorException($message, 0, $severity, $file, $line);
-            };
-        }
-
-        set_error_handler($handler);
         $unserializeHandler = ini_set('unserialize_callback_func', __CLASS__ . '::handleUnserializeCallback');
         try {
             if (PHP_VERSION_ID < 70000) {
-                return unserialize($value);
+                return Thrower::call('unserialize', $value);
             }
 
-            return unserialize($value, $options);
+            return Thrower::call('unserialize', $value, $options);
         } catch (ParseException $e) {
             throw $e;
         } catch (\Error $e) {
         } catch (\Exception $e) {
         } finally {
-            restore_error_handler();
             ini_set('unserialize_callback_func', $unserializeHandler);
         }
 

--- a/src/Thrower.php
+++ b/src/Thrower.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Bolt\Common;
+
+/**
+ * Temporarily set PHP error reporting to throw ErrorExceptions.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class Thrower
+{
+    /** @var callable */
+    private static $handler;
+
+    /** @noinspection PhpDocSignatureInspection */
+
+    /**
+     * Call the given callable with given args, but throws an ErrorException when an error/warning/notice is triggered.
+     *
+     * @param callable $callable
+     * @param array    ...$args
+     *
+     * @throws \ErrorException when an error/warning/notice is triggered
+     *
+     * @return mixed
+     */
+    public static function call(callable $callable)
+    {
+        static::set();
+        try {
+            return call_user_func_array($callable, array_slice(func_get_args(), 1));
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * Set the error handler to throw \ErrorExceptions (excluding deprecated warnings).
+     *
+     * To revert call {@see restore_error_handler}.
+     *
+     * @return callable|null the previous handler
+     */
+    public static function set()
+    {
+        if (!static::$handler) {
+            static::$handler = function ($severity, $message, $file, $line) {
+                throw new \ErrorException($message, 0, $severity, $file, $line);
+            };
+        }
+
+        return set_error_handler(static::$handler, E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    private function __construct()
+    {
+    }
+}

--- a/tests/ThrowerTest.php
+++ b/tests/ThrowerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Bolt\Common\Tests;
+
+use Bolt\Common\Thrower;
+use PHPUnit\Framework\TestCase;
+
+class ThrowerTest extends TestCase
+{
+    public function testSet()
+    {
+        $orig = $this->getHandler();
+
+        Thrower::set();
+
+        $current = $this->getHandler();
+
+        $this->assertNotSame($orig, $current);
+        restore_error_handler();
+
+        $now = $this->getHandler();
+        $this->assertSame($orig, $now);
+    }
+
+    public function testSetUsesSameHandler()
+    {
+        Thrower::set();
+        Thrower::set();
+
+        $handler1 = $this->getHandler();
+        restore_error_handler();
+        $handler2 = $this->getHandler();
+        restore_error_handler();
+
+        $this->assertSame($handler1, $handler2);
+    }
+
+    public function testCall()
+    {
+        $origHandler = $this->getHandler();
+
+        $result = Thrower::call(
+            function ($arg1, $arg2) {
+                $this->assertSame('arg1', $arg1);
+                $this->assertSame('arg2', $arg2);
+
+                return 'blue';
+            },
+            'arg1',
+            'arg2'
+        );
+
+        $this->assertSame('blue', $result);
+
+        $nowHandler = $this->getHandler();
+        $this->assertSame($origHandler, $nowHandler);
+    }
+
+    public function testCallWithError()
+    {
+        $origHandler = $this->getHandler();
+
+        $e = null;
+        try {
+            Thrower::call(
+                function () {
+                    trigger_error('I errored', E_USER_ERROR);
+                }
+            );
+        } catch (\ErrorException $e) {
+        } catch (\Exception $e) {
+        }
+
+        $this->assertInstanceOf(\ErrorException::class, $e);
+        $this->assertSame('I errored', $e->getMessage());
+        $this->assertSame(E_USER_ERROR, $e->getSeverity());
+
+        $nowHandler = $this->getHandler();
+        $this->assertSame($origHandler, $nowHandler);
+    }
+
+    private function getHandler()
+    {
+        $handler = set_error_handler('var_dump');
+        restore_error_handler();
+
+        return $handler;
+    }
+}


### PR DESCRIPTION
It's pretty easy to silence errors, just use the `@` operator (not that I'm encouraging the use of it).
But it is harder to convert it to an exception. This adds that functionality.

This helps out us internally and I figured it could be used outside of this library.

```php
Thrower::call('unserialize', $value);
```

Thrower ignores `E_DEPRECATED` and `E_USER_DEPRECATED` errors as they are special cases.