### PR TITLE
Deprecated::method suggest method of suggested class

### DIFF
--- a/tests/DeprecatedTest.php
+++ b/tests/DeprecatedTest.php
@@ -62,6 +62,9 @@ class DeprecatedTest extends TestCase
 
         new TestDeprecatedClass(true);
         $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass is deprecated.');
+
+        TestDeprecatedClass::getArrayCopy();
+        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::getArrayCopy() is deprecated. Use ArrayObject::getArrayCopy() instead.');
     }
 
     public function testClass()

--- a/tests/Fixtures/TestDeprecatedClass.php
+++ b/tests/Fixtures/TestDeprecatedClass.php
@@ -47,6 +47,11 @@ class TestDeprecatedClass
     {
         Deprecated::method();
     }
+
+    public static function getArrayCopy()
+    {
+        Deprecated::method(null, \ArrayObject::class);
+    }
 }
 
 // @codingStandardsIgnoreLine


### PR DESCRIPTION
If `$suggest` is a class name and that class has a method with the same name as the one being deprecated use that in the suggestion sentence.

Example:
```php
class Foo
{
    public function hello() {}
}

class Bar extends Foo
{
    public function hello()
    {
        Deprecated::method(1.1, Foo::class);
    }
}
```
Produces:
> Bar::hello() is deprecated. Use Foo::hello() instead.

----

Previously it was:
> Bar::hello() is deprecated. Use Foo instead.

Or the call had to be:
```php
public function hello()
{
    Deprecated::method(1.1, Foo::class . '::hello');
}
```
And it doesn't seem to make sense to duplicate the method name in the suggestion.