### PR TITLE
Fix Deprecated::method in constructors

### DIFF
--- a/src/Deprecated.php
+++ b/src/Deprecated.php
@@ -33,6 +33,7 @@ class Deprecated
     public static function method($since = null, $suggest = '', $method = null)
     {
         $function = $method;
+        $constructor = false;
         if ($method === null) {
             $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
             $function = $caller['function'];
@@ -42,6 +43,7 @@ class Deprecated
             }
             if ($function === '__construct') {
                 $method = $caller['class'];
+                $constructor = true;
             } else {
                 $method = (isset($caller['class']) ? $caller['class'] . '::' : '') . $caller['function'];
             }
@@ -52,13 +54,13 @@ class Deprecated
             // Append () if it is a method/function (not a class)
             if (!class_exists($suggest)) {
                 $suggest .= '()';
-            } elseif (method_exists($suggest, $function)) {
+            } elseif (!$constructor && method_exists($suggest, $function)) {
                 $suggest = $suggest . '::' . $function . '()';
             }
             $suggest = "Use $suggest instead.";
         }
 
-        if ($function === '__construct') {
+        if ($constructor) {
             static::cls($method, $since, $suggest);
 
             return;

--- a/tests/DeprecatedTest.php
+++ b/tests/DeprecatedTest.php
@@ -61,7 +61,7 @@ class DeprecatedTest extends TestCase
         $this->assertDeprecation('unset(Bolt\Common\Tests\Fixtures\TestDeprecatedClass::magic) is deprecated.');
 
         new TestDeprecatedClass(true);
-        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass is deprecated.');
+        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass is deprecated. Use ArrayObject instead.');
 
         TestDeprecatedClass::getArrayCopy();
         $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::getArrayCopy() is deprecated. Use ArrayObject::getArrayCopy() instead.');

--- a/tests/Fixtures/TestDeprecatedClass.php
+++ b/tests/Fixtures/TestDeprecatedClass.php
@@ -9,7 +9,7 @@ class TestDeprecatedClass
     public function __construct($deprecatedClass = false)
     {
         if ($deprecatedClass) {
-            Deprecated::method();
+            Deprecated::method(null, \ArrayObject::class);
         }
     }
 


### PR DESCRIPTION
Fix for change introduced in #14 

```php
class Foo
{
    public function __construct()
    {
        Deprecated::method(null, Bar::class)
    }
}
```
Previously:
```
Foo is deprecated. Use Bar::__construct() instead.
```
Now:
```
Foo is deprecated. Use Bar instead.
```
