### PR TITLE
Json empty string handling and more

### DIFF
--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -66,7 +66,7 @@ class ParseException extends \RuntimeException
 
         $message = 'JSON parsing failed: ' . $message;
 
-        return new static($message, $line, $snippet, JSON_ERROR_SYNTAX, $exception);
+        return new static($message, $line, $snippet, JSON_ERROR_SYNTAX);
     }
 
     /**

--- a/src/Json.php
+++ b/src/Json.php
@@ -13,6 +13,24 @@ use Seld\JsonLint\ParsingException;
 final class Json
 {
     /**
+     * Dump JSON easy to read for humans.
+     * Shortcut for JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE.
+     */
+    const HUMAN = 448;
+
+    /**
+     * Dump JSON without escaping slashes or unicode.
+     * Shortcut for JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE.
+     */
+    const UNESCAPED = 320;
+
+    /**
+     * Dump JSON safe for HTML.
+     * Shortcut for JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT.
+     */
+    const HTML = 15;
+
+    /**
      * Dumps a array/object into a JSON string.
      *
      * @param mixed $data    Data to encode into a formatted JSON string
@@ -24,7 +42,7 @@ final class Json
      *
      * @return string
      */
-    public static function dump($data, $options = 448, $depth = 512)
+    public static function dump($data, $options = self::HUMAN, $depth = 512)
     {
         $json = @json_encode($data, $options, $depth);
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -62,10 +62,12 @@ final class Json
             return null;
         }
 
+        $json = (string) $json;
+
         $data = @json_decode($json, true, $depth, $options);
 
-        if ($data === null && ($code = json_last_error()) !== JSON_ERROR_NONE) {
-            if ($code === JSON_ERROR_UTF8 || $code === JSON_ERROR_DEPTH) {
+        if ($data === null && ($json === '' || ($code = json_last_error()) !== JSON_ERROR_NONE)) {
+            if (isset($code) && ($code === JSON_ERROR_UTF8 || $code === JSON_ERROR_DEPTH)) {
                 throw new ParseException(sprintf('JSON parsing failed: %s', json_last_error_msg()), -1, null, $code);
             }
 
@@ -92,8 +94,15 @@ final class Json
             return false;
         }
 
+        $json = (string) $json;
+
+        // valid for PHP 5.x, invalid for PHP 7.x
+        if ($json === '') {
+            return false;
+        }
+
         // Don't call our parse(), because we don't need the extra syntax checking.
-        @json_decode((string) $json);
+        @json_decode($json);
 
         return json_last_error() === JSON_ERROR_NONE;
     }

--- a/src/Json.php
+++ b/src/Json.php
@@ -42,7 +42,7 @@ final class Json
      *
      * @return string
      */
-    public static function dump($data, $options = self::HUMAN, $depth = 512)
+    public static function dump($data, $options = self::UNESCAPED, $depth = 512)
     {
         $json = @json_encode($data, $options, $depth);
 

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -270,13 +270,9 @@ class JsonTest extends TestCase
         $this->fail('Should have thrown ' . DumpException::class);
     }
 
-    private function assertJsonFormat($json, $data, $options = null)
+    private function assertJsonFormat($json, $data, $options = Json::HUMAN)
     {
-        if ($options === null) {
-            $this->assertEquals($json, Json::dump($data));
-        } else {
-            $this->assertEquals($json, Json::dump($data, $options));
-        }
+        $this->assertEquals($json, Json::dump($data, $options));
     }
 
     public function testDumpFail()

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -228,6 +228,16 @@ class JsonTest extends TestCase
         $this->assertJsonFormat('"\\u018c"', $data, 0);
     }
 
+    public function testDumpEscapesLineTerminators()
+    {
+        $this->assertJsonFormat('"JS\\u2029ON ro\\u2028cks"', 'JS ON ro cks', JSON_UNESCAPED_UNICODE);
+        $this->assertJsonFormat('"JS\\u2029ON ro\\u2028cks"', 'JS ON ro cks', JSON_UNESCAPED_UNICODE);
+
+        if (PHP_VERSION_ID >= 70100) {
+            $this->assertJsonFormat('"JS ON ro cks"', 'JS ON ro cks', JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS);
+        }
+    }
+
     public function testDumpConvertsInvalidEncodingAsLatin9()
     {
         $data = "\xA4\xA6\xA8\xB4\xB8\xBC\xBD\xBE";

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -22,6 +22,16 @@ class JsonTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], Json::parse('{"foo": "bar"}'));
     }
 
+    public function testParseErrorEmptyString()
+    {
+        $this->expectParseException('', 0);
+    }
+
+    public function testParseErrorObjectEmptyString()
+    {
+        $this->expectParseException(new TestStringable(''), 0);
+    }
+
     public function testParseErrorDetectExtraComma()
     {
         $json = '{
@@ -282,6 +292,8 @@ class JsonTest extends TestCase
     {
         $this->assertFalse(Json::test(null));
         $this->assertFalse(Json::test(123));
+        $this->assertFalse(Json::test(''));
+        $this->assertFalse(Json::test(new TestStringable('')));
         $this->assertTrue(Json::test('{}'));
         $this->assertTrue(Json::test(new TestStringable('{}')));
 


### PR DESCRIPTION
- Removed pretty print by default
- Empty strings bad
- Escape line terminators
- Constant shortcut flags