### PR TITLE
Deprecation method updates

### DIFF
--- a/src/Deprecated.php
+++ b/src/Deprecated.php
@@ -54,9 +54,9 @@ class Deprecated
                 } else {
                     if ($function === '__call' || $function === '__callStatic') {
                         $caller = debug_backtrace(false, $frame + 1)[$frame]; // with args
-                        $caller['function'] = $caller['args'][0];
+                        $function = $caller['args'][0];
                     }
-                    $method = $caller['class'] . '::' . $caller['function'];
+                    $method = $caller['class'] . '::' . $function;
                 }
             } else {
                 $method = $caller['function'];

--- a/src/Deprecated.php
+++ b/src/Deprecated.php
@@ -52,7 +52,7 @@ class Deprecated
                     $method = $caller['class'];
                     $constructor = true;
                 } else {
-                    if ($function[0] === '_' && in_array($function, ['__call', '__callStatic', '__set', '__get', '__isset', '__unset'], true)) {
+                    if ($function === '__call' || $function === '__callStatic') {
                         $caller = debug_backtrace(false, $frame + 1)[$frame]; // with args
                         $caller['function'] = $caller['args'][0];
                     }
@@ -86,19 +86,6 @@ class Deprecated
             static::cls($method, $since, $suggest);
 
             return;
-        }
-
-        if ($function[0] === '_') {
-            if ($function === '__isset' || $function === '__unset') {
-                static::warn(substr($function, 2) . "($method)", $since, $suggest);
-
-                return;
-            }
-            if ($function === '__set' || $function === '__get') {
-                static::warn(strtoupper($function[2]) . "etting $method", $since, $suggest);
-
-                return;
-            }
         }
 
         static::warn($method . '()', $since, $suggest);

--- a/src/Deprecated.php
+++ b/src/Deprecated.php
@@ -60,6 +60,12 @@ class Deprecated
                 }
             } else {
                 $method = $caller['function'];
+
+                // Assert the method isn't called directly from a script,
+                // else we would be saying "require() is deprecated" lol.
+                if (!function_exists($method)) {
+                    throw new \InvalidArgumentException(sprintf('%s() must be called from within a function/method.', __METHOD__));
+                }
             }
         } else {
             Assert::stringNotEmpty($method, 'Expected a non-empty string. Got: %s');

--- a/tests/DeprecatedTest.php
+++ b/tests/DeprecatedTest.php
@@ -47,12 +47,19 @@ class DeprecatedTest extends TestCase
     {
         /* @noinspection PhpUndefinedMethodInspection */
         TestDeprecatedClass::magicStatic();
-        $this->assertDeprecation(TestDeprecatedClass::class . '::magicStatic() is deprecated.');
+        $this->assertDeprecation(TestDeprecatedClass::class . '::magicStatic() is deprecated. Use ArrayObject instead.');
+
+        /* @noinspection PhpUndefinedMethodInspection */
+        TestDeprecatedClass::append();
+        $this->assertDeprecation(TestDeprecatedClass::class . '::append() is deprecated. Use ArrayObject::append() instead.');
 
         $cls = new TestDeprecatedClass();
         /* @noinspection PhpUndefinedMethodInspection */
         $cls->magic();
-        $this->assertDeprecation(TestDeprecatedClass::class . '::magic() is deprecated.');
+        $this->assertDeprecation(TestDeprecatedClass::class . '::magic() is deprecated. Use ArrayObject instead.');
+        /* @noinspection PhpUndefinedMethodInspection */
+        $cls->append();
+        $this->assertDeprecation(TestDeprecatedClass::class . '::append() is deprecated. Use ArrayObject::append() instead.');
     }
 
     public function testMethodFunction()

--- a/tests/DeprecatedTest.php
+++ b/tests/DeprecatedTest.php
@@ -35,9 +35,6 @@ class DeprecatedTest extends TestCase
         TestDeprecatedClass::foo();
         $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::foo() is deprecated.');
 
-        Fixtures\deprecatedFunction();
-        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\deprecatedFunction() is deprecated.');
-
         /* @noinspection PhpUndefinedMethodInspection */
         TestDeprecatedClass::magicStatic();
         $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::magicStatic() is deprecated.');
@@ -68,6 +65,12 @@ class DeprecatedTest extends TestCase
 
         TestDeprecatedClass::someMethod();
         $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::someMethod() is deprecated since 1.1 and will be removed in 2.0. Use ArrayObject instead.');
+    }
+
+    public function testMethodFunction()
+    {
+        eval('namespace Bolt\Common { function deprecatedFunction() { Deprecated::method(); }; deprecatedFunction(); }');
+        $this->assertDeprecation('Bolt\Common\deprecatedFunction() is deprecated.');
     }
 
     /**

--- a/tests/DeprecatedTest.php
+++ b/tests/DeprecatedTest.php
@@ -17,60 +17,71 @@ class DeprecatedTest extends TestCase
     {
         Deprecated::method(3.0, 'baz', 'Foo::bar');
         $this->assertDeprecation('Foo::bar() is deprecated since 3.0 and will be removed in 4.0. Use baz() instead.');
-
-        $realClass = static::class;
-        Deprecated::method(3.0, $realClass, 'Foo::bar');
-        $this->assertDeprecation(
-            "Foo::bar() is deprecated since 3.0 and will be removed in 4.0. Use $realClass instead."
-        );
-
-        Deprecated::method(3.0, 'Do it this way instead.', 'Foo::bar');
-        $this->assertDeprecation(
-            'Foo::bar() is deprecated since 3.0 and will be removed in 4.0. Do it this way instead.'
-        );
     }
 
-    public function testMethodUsingBacktrace()
+    public function testMethodSentenceSuggestion()
+    {
+        Deprecated::method(null, 'Do it this way instead.', 'Foo::bar');
+        $this->assertDeprecation('Foo::bar() is deprecated. Do it this way instead.');
+    }
+
+    public function testMethodSuggestClass()
     {
         TestDeprecatedClass::foo();
-        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::foo() is deprecated.');
+        $this->assertDeprecation(TestDeprecatedClass::class . '::foo() is deprecated. Use ArrayObject instead.');
+    }
 
+    public function testMethodSuggestClassWithMatchingMethod()
+    {
+        TestDeprecatedClass::getArrayCopy();
+        $this->assertDeprecation(TestDeprecatedClass::class . '::getArrayCopy() is deprecated. Use ArrayObject::getArrayCopy() instead.');
+    }
+
+    public function testMethodConstructor()
+    {
+        new TestDeprecatedClass(true);
+        $this->assertDeprecation(TestDeprecatedClass::class . ' is deprecated. Use ArrayObject instead.');
+    }
+
+    public function testMethodMagicCall()
+    {
         /* @noinspection PhpUndefinedMethodInspection */
         TestDeprecatedClass::magicStatic();
-        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::magicStatic() is deprecated.');
+        $this->assertDeprecation(TestDeprecatedClass::class . '::magicStatic() is deprecated.');
 
         $cls = new TestDeprecatedClass();
         /* @noinspection PhpUndefinedMethodInspection */
         $cls->magic();
-        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::magic() is deprecated.');
+        $this->assertDeprecation(TestDeprecatedClass::class . '::magic() is deprecated.');
+    }
 
+    public function testMethodMagicProperty()
+    {
+        $cls = new TestDeprecatedClass();
         /* @noinspection PhpUndefinedFieldInspection */
         $cls->magic;
-        $this->assertDeprecation('Getting Bolt\Common\Tests\Fixtures\TestDeprecatedClass::magic is deprecated.');
+        $this->assertDeprecation('Getting ' . TestDeprecatedClass::class . '::magic is deprecated.');
 
         /* @noinspection PhpUndefinedFieldInspection */
         $cls->magic = 'derp';
-        $this->assertDeprecation('Setting Bolt\Common\Tests\Fixtures\TestDeprecatedClass::magic is deprecated.');
+        $this->assertDeprecation('Setting ' . TestDeprecatedClass::class . '::magic is deprecated.');
 
         isset($cls->magic);
-        $this->assertDeprecation('isset(Bolt\Common\Tests\Fixtures\TestDeprecatedClass::magic) is deprecated.');
+        $this->assertDeprecation('isset(' . TestDeprecatedClass::class . '::magic) is deprecated.');
         unset($cls->magic);
-        $this->assertDeprecation('unset(Bolt\Common\Tests\Fixtures\TestDeprecatedClass::magic) is deprecated.');
-
-        new TestDeprecatedClass(true);
-        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass is deprecated. Use ArrayObject instead.');
-
-        TestDeprecatedClass::getArrayCopy();
-        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::getArrayCopy() is deprecated. Use ArrayObject::getArrayCopy() instead.');
-
-        TestDeprecatedClass::someMethod();
-        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::someMethod() is deprecated since 1.1 and will be removed in 2.0. Use ArrayObject instead.');
+        $this->assertDeprecation('unset(' . TestDeprecatedClass::class . '::magic) is deprecated.');
     }
 
     public function testMethodFunction()
     {
         eval('namespace Bolt\Common { function deprecatedFunction() { Deprecated::method(); }; deprecatedFunction(); }');
         $this->assertDeprecation('Bolt\Common\deprecatedFunction() is deprecated.');
+    }
+
+    public function testMethodIndex()
+    {
+        TestDeprecatedClass::someMethod();
+        $this->assertDeprecation(TestDeprecatedClass::class . '::someMethod() is deprecated. Use ArrayObject instead.');
     }
 
     /**

--- a/tests/DeprecatedTest.php
+++ b/tests/DeprecatedTest.php
@@ -106,6 +106,16 @@ class DeprecatedTest extends TestCase
         Deprecated::method(null, null, '');
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Bolt\Common\Deprecated::method() must be called from within a function/method.
+     */
+    public function testMethodNotFunction()
+    {
+        // Using eval here because it is the easiest, but this also applies to require(_once)/include(_once)
+        eval('\Bolt\Common\Deprecated::method();');
+    }
+
     public function testClass()
     {
         Deprecated::cls('Foo\Bar');

--- a/tests/DeprecatedTest.php
+++ b/tests/DeprecatedTest.php
@@ -55,23 +55,6 @@ class DeprecatedTest extends TestCase
         $this->assertDeprecation(TestDeprecatedClass::class . '::magic() is deprecated.');
     }
 
-    public function testMethodMagicProperty()
-    {
-        $cls = new TestDeprecatedClass();
-        /* @noinspection PhpUndefinedFieldInspection */
-        $cls->magic;
-        $this->assertDeprecation('Getting ' . TestDeprecatedClass::class . '::magic is deprecated.');
-
-        /* @noinspection PhpUndefinedFieldInspection */
-        $cls->magic = 'derp';
-        $this->assertDeprecation('Setting ' . TestDeprecatedClass::class . '::magic is deprecated.');
-
-        isset($cls->magic);
-        $this->assertDeprecation('isset(' . TestDeprecatedClass::class . '::magic) is deprecated.');
-        unset($cls->magic);
-        $this->assertDeprecation('unset(' . TestDeprecatedClass::class . '::magic) is deprecated.');
-    }
-
     public function testMethodFunction()
     {
         eval('namespace Bolt\Common { function deprecatedFunction() { Deprecated::method(); }; deprecatedFunction(); }');

--- a/tests/DeprecatedTest.php
+++ b/tests/DeprecatedTest.php
@@ -65,6 +65,45 @@ class DeprecatedTest extends TestCase
 
         TestDeprecatedClass::getArrayCopy();
         $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::getArrayCopy() is deprecated. Use ArrayObject::getArrayCopy() instead.');
+
+        TestDeprecatedClass::someMethod();
+        $this->assertDeprecation('Bolt\Common\Tests\Fixtures\TestDeprecatedClass::someMethod() is deprecated since 1.1 and will be removed in 2.0. Use ArrayObject instead.');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Expected a value greater than or equal to 0. Got: -1
+     */
+    public function testMethodIndexNegative()
+    {
+        Deprecated::method(null, null, -1);
+    }
+
+    /**
+     * @expectedException \OutOfBoundsException
+     * @expectedExceptionMessage 9000 is greater than the current call stack
+     */
+    public function testMethodIndexOutOfBounds()
+    {
+        Deprecated::method(null, null, 9000);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Expected a non-empty string. Got: boolean
+     */
+    public function testMethodNotIntOrString()
+    {
+        Deprecated::method(null, null, false);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Expected a non-empty string. Got: ""
+     */
+    public function testMethodEmptyString()
+    {
+        Deprecated::method(null, null, '');
     }
 
     public function testClass()

--- a/tests/Fixtures/TestDeprecatedClass.php
+++ b/tests/Fixtures/TestDeprecatedClass.php
@@ -15,7 +15,7 @@ class TestDeprecatedClass
 
     public static function foo()
     {
-        Deprecated::method();
+        Deprecated::method(null, \ArrayObject::class);
     }
 
     public function __call($name, $arguments)
@@ -60,6 +60,6 @@ class TestDeprecatedClass
 
     private static function deprecated()
     {
-        Deprecated::method(1.1, \ArrayObject::class, 1);
+        Deprecated::method(null, \ArrayObject::class, 1);
     }
 }

--- a/tests/Fixtures/TestDeprecatedClass.php
+++ b/tests/Fixtures/TestDeprecatedClass.php
@@ -20,12 +20,12 @@ class TestDeprecatedClass
 
     public function __call($name, $arguments)
     {
-        Deprecated::method();
+        Deprecated::method(null, \ArrayObject::class);
     }
 
     public static function __callStatic($name, $arguments)
     {
-        Deprecated::method();
+        Deprecated::method(null, \ArrayObject::class);
     }
 
     public static function getArrayCopy()

--- a/tests/Fixtures/TestDeprecatedClass.php
+++ b/tests/Fixtures/TestDeprecatedClass.php
@@ -63,9 +63,3 @@ class TestDeprecatedClass
         Deprecated::method(1.1, \ArrayObject::class, 1);
     }
 }
-
-// @codingStandardsIgnoreLine
-function deprecatedFunction()
-{
-    Deprecated::method();
-}

--- a/tests/Fixtures/TestDeprecatedClass.php
+++ b/tests/Fixtures/TestDeprecatedClass.php
@@ -52,6 +52,16 @@ class TestDeprecatedClass
     {
         Deprecated::method(null, \ArrayObject::class);
     }
+
+    public static function someMethod()
+    {
+        static::deprecated();
+    }
+
+    private static function deprecated()
+    {
+        Deprecated::method(1.1, \ArrayObject::class, 1);
+    }
 }
 
 // @codingStandardsIgnoreLine

--- a/tests/Fixtures/TestDeprecatedClass.php
+++ b/tests/Fixtures/TestDeprecatedClass.php
@@ -28,26 +28,6 @@ class TestDeprecatedClass
         Deprecated::method();
     }
 
-    public function __get($name)
-    {
-        Deprecated::method();
-    }
-
-    public function __set($name, $value)
-    {
-        Deprecated::method();
-    }
-
-    public function __isset($name)
-    {
-        Deprecated::method();
-    }
-
-    public function __unset($name)
-    {
-        Deprecated::method();
-    }
-
     public static function getArrayCopy()
     {
         Deprecated::method(null, \ArrayObject::class);


### PR DESCRIPTION
- Allow call stack index to be passed into `Deprecated::method` subject parameter so that helper methods can be created.
- Magic call methods now suggest corresponding method on suggested class
- Removed functionality for magic properties (i.e. `__get`). Lots of code for a very small edge case.
- Refactored stacktrace logic into separate method.

The code is much more readable now and the separate `getCaller` method allows for more helper methods in the future with similar functionality (maybe like a `Deprecated::properties` method). But since performance is a hot topic here the extra method call should be evaluated vs readability and extendability.