### PR TITLE
Allow PHP 8.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=7.2.5 || ^8.0",
         "seld/jsonlint": "^1.7",
         "webmozart/assert": "^1.6"
     },


### PR DESCRIPTION
Just tried to `composer update` with PHP 8.0 and this is one hurdle we have to pass 😄 