### PR TITLE
[4.2] Add Str::stringifyValue to cast an iterable into string

### DIFF
--- a/src/Str.php
+++ b/src/Str.php
@@ -633,6 +633,15 @@ class Str
 
         return preg_last_error() === PREG_NO_ERROR;
     }
+    
+    /**
+     * Converts an iterable into a string.
+     * @return string
+     */
+    public static function stringifyValue($value): string
+    {
+        return is_iterable($value) ? sprintf('[%s]', implode(',', $value)) : $value;
+    }
 
     public static function decode(string $str): string
     {


### PR DESCRIPTION
See #39 but applies to `bolt/common` 2.0 and Bolt 4.2.